### PR TITLE
Update README.md with Mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Also cut the number of requests to sites in half, effectively killing HTTP 429 E
   - [How it Works](#how-it-works)
   - [Features](#features)
   - [Tutorial](#tutorial)
-    - [Windows](#windows)
+    - [Windows and Mac](#windows)
       - [Python Installation](#python-installation)
         - [Anaconda](#anaconda)
         - [Python Base](#python-base)
@@ -83,9 +83,9 @@ Here are some features we figure are worth noting.
 
 # Tutorial
 The way that you will run spidy depends on the way you have Python installed.<br>
-Spidy can be run from the command line, a Python IDE, or (on Windows systems) by launching the `.bat` file.
+Spidy can be run from the command line (on Mac systems), a Python IDE, or (on Windows systems) by launching the `.bat` file.
 
-## Windows
+## Windows and Mac
 
 ### Python Installation
 There are many different versions of [Python](https://www.python.org/about/), and hundreds of different installations for each them.<br>


### PR DESCRIPTION
In the `contributing.md` file you mention including mac support under a notable TODO. I forked your repo and ran spidy using the `crawler.py` file. It ran successfully on my machine - macOS Sierra version 10.12.6. The installation and how to run instructions are exactly the same. You can install requirements and run the crawler through the command line on the mac. So I don't think you need any major changes to the docs for Mac users. I think it may be enough to say that you can run it on a Mac. I added that to the `README.md`.