### PR TITLE
Respect robots

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -9,6 +9,7 @@ import requests
 from os import path, makedirs
 from lxml import etree
 from lxml.html import iterlinks, resolve_base_href
+from reppy.robots import Robots
 
 VERSION = '1.4.2'
 
@@ -119,13 +120,19 @@ def crawl(url):
         write_log('[CRAWL]: Found {0} links on {1}'.format(len(links), url))
 
 
-def check_link(item):
+def allow_all(ignore_url):
+    return False
+
+
+def check_link(item, robots_allowed=allow_all):
     """
     Returns True if item is not a valid url.
     Returns False if item passes all inspections (is valid url).
     """
     # Shortest possible url being 'http://a.b', and
     # Links longer than 255 characters are usually too long for the filesystem to handle.
+    if not robots_allowed(item):
+        return True
     if RESTRICT:
         if DOMAIN not in item:
             return True
@@ -519,10 +526,10 @@ yes = ['y', 'yes', 'Y', 'Yes', 'True', 'true']
 no = ['n', 'no', 'N', 'No', 'False', 'false']
 
 # Initialize variables as empty that will be needed in the global scope
-HEADER = ''
+HEADER = {}
 SAVE_COUNT, MAX_NEW_ERRORS, MAX_KNOWN_ERRORS, MAX_HTTP_ERRORS = 0, 0, 0, 0
 MAX_NEW_MIMES = 0
-RESTRICT, DOMAIN = False, ''
+RESTRICT, DOMAIN, RESPECT_ROBOTS = False, '', False
 USE_CONFIG, OVERWRITE, RAISE_ERRORS, ZIP_FILES, OVERRIDE_SIZE = False, False, False, False, False
 SAVE_PAGES, SAVE_WORDS = False, False
 TODO_FILE, DONE_FILE, WORD_FILE = '', '', ''
@@ -542,7 +549,7 @@ def init():
     global MAX_NEW_ERRORS, MAX_KNOWN_ERRORS, MAX_HTTP_ERRORS, MAX_NEW_MIMES
     global USE_CONFIG, OVERWRITE, RAISE_ERRORS, ZIP_FILES, OVERRIDE_SIZE, SAVE_WORDS, SAVE_PAGES, SAVE_COUNT
     global TODO_FILE, DONE_FILE, ERR_LOG_FILE, WORD_FILE
-    global RESTRICT, DOMAIN
+    global RESTRICT, DOMAIN, RESPECT_ROBOTS
     global WORDS, TODO, DONE
 
     # Getting Arguments
@@ -755,6 +762,17 @@ def init():
         else:
             MAX_NEW_MIMES = int(input_)
 
+        write_log('[INPUT]: Should spidy respect robots.txt? (y/n) (Default: No):')
+        input_ = input()
+        if not bool(input_):
+            RESPECT_ROBOTS = False
+        elif input_ in yes:
+            RESPECT_ROBOTS = True
+        elif input_ in no:
+            RESPECT_ROBOTS = False
+        else:
+            handle_invalid_input()
+
         # Remove INPUT variable from memory
         del input_
 
@@ -787,6 +805,18 @@ def init():
         TODO += START
 
 
+def init_robot_checker(respect_robots, user_agent, start_url):
+    if respect_robots:
+        start_path = parse.urlparse(start_url).path
+        robots_url = start_url.replace(start_path, '/robots.txt')
+        write_log('[INFO]: Reading robots file: {0}'.format(robots_url))
+        robots = Robots.fetch(robots_url)
+        checker = robots.agent(user_agent)
+        return checker.allowed
+    else:
+        return allow_all
+
+
 def main():
     """
     The main function of spidy.
@@ -799,7 +829,7 @@ def main():
     global MAX_NEW_ERRORS, MAX_KNOWN_ERRORS, MAX_HTTP_ERRORS, MAX_NEW_MIMES
     global USE_CONFIG, OVERWRITE, RAISE_ERRORS, ZIP_FILES, OVERRIDE_SIZE, SAVE_WORDS, SAVE_PAGES, SAVE_COUNT
     global TODO_FILE, DONE_FILE, ERR_LOG_FILE, WORD_FILE
-    global RESTRICT, DOMAIN
+    global RESTRICT, DOMAIN, RESPECT_ROBOTS
     global WORDS, TODO, DONE
 
     init()
@@ -817,9 +847,12 @@ def main():
     write_log('[INIT]: Successfully started spidy Web Crawler version {0}...'.format(VERSION))
     log('LOG: Successfully started crawler.')
 
+    robots_allowed = init_robot_checker(RESPECT_ROBOTS, HEADER['User-Agent'], TODO[0])
+
     write_log('[INFO]: TODO first value: {0}'.format(TODO[0]))
 
     write_log('[INFO]: Using headers: {0}'.format(HEADER))
+
 
     while len(TODO) != 0:  # While there are links to check
         try:
@@ -839,7 +872,7 @@ def main():
                     # Reset variables
                     COUNTER = 0
                     WORDS.clear()
-            elif check_link(TODO[0]):  # If the link is invalid
+            elif check_link(TODO[0], robots_allowed):  # If the link is invalid
                 del TODO[0]
             # Crawl the page
             else:

--- a/crawler.py
+++ b/crawler.py
@@ -5,6 +5,7 @@ Built by rivermont and FalconWarriorr
 import time
 import shutil
 import requests
+import urllib
 
 from os import path, makedirs
 from lxml import etree
@@ -807,7 +808,7 @@ def init():
 
 def init_robot_checker(respect_robots, user_agent, start_url):
     if respect_robots:
-        start_path = parse.urlparse(start_url).path
+        start_path = urllib.parse.urlparse(start_url).path
         robots_url = start_url.replace(start_path, '/robots.txt')
         write_log('[INFO]: Reading robots file: {0}'.format(robots_url))
         robots = Robots.fetch(robots_url)
@@ -852,7 +853,6 @@ def main():
     write_log('[INFO]: TODO first value: {0}'.format(TODO[0]))
 
     write_log('[INFO]: Using headers: {0}'.format(HEADER))
-
 
     while len(TODO) != 0:  # While there are links to check
         try:

--- a/crawler.py
+++ b/crawler.py
@@ -122,7 +122,7 @@ def crawl(url):
 
 
 def allow_all(ignore_url):
-    return False
+    return True
 
 
 def check_link(item, robots_allowed=allow_all):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 lxml
 flake8
+reppy

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,8 @@ from crawler import (
     check_link,
     check_word,
     check_path,
+    HEADERS,
+    init_robot_checker,
     make_words,
     make_file_path,
     mime_lookup,
@@ -31,6 +33,36 @@ class CrawlerTestCase(unittest.TestCase):
     def test_check_link_given_short_url(self):
         url = "http://a"
         self.assertTrue(check_link(url))
+
+    # Tests for check_link respecting robots.txt
+
+    def test_robots_given_allowed_url(self):
+        # allowed expliticly
+        url = "http://www.google.com/m/finance"
+        checker = init_robot_checker(True, 'duckduckbot', url)
+
+        self.assertFalse(check_link(url, checker))
+
+    def test_robots_given_asterisk_path_allowed_url(self):
+        # allowed by /*/*/tree/master
+        url = "http://github.com/rivermont/spidy/tree/master"
+        checker = init_robot_checker(True, 'duckduckbot', url)
+
+        self.assertFalse(check_link(url, checker))
+
+    def test_robots_given_lower_path_allowed_url(self):
+        # allowed by /search/about after /search is forbidden
+        url = "http://google.com/search/about"
+        checker = init_robot_checker(True, 'duckduckbot', url)
+
+        self.assertFalse(check_link(url, checker))
+
+    def test_robots_given_forbidden_url(self):
+        # prohibited explicitly
+        url = "http://github.com/search"
+        checker = init_robot_checker(True, 'duckduckbot', url)
+
+        self.assertTrue(check_link(url, checker))
 
     # Tests for check_word
 

--- a/tests.py
+++ b/tests.py
@@ -5,7 +5,6 @@ from crawler import (
     check_link,
     check_word,
     check_path,
-    HEADERS,
     init_robot_checker,
     make_words,
     make_file_path,


### PR DESCRIPTION
Added dependency on a fast powerful library to support this.
The urllib.robotparser library is very primitive by comparison.

Followed existing pattern for configuration, defaulting respect
as disabled.

Fixes #30