### PR TITLE
Updated robots.txt URL formatter

### DIFF
--- a/spidy/crawler.py
+++ b/spidy/crawler.py
@@ -212,7 +212,7 @@ class RobotsIndex(object):
 
     def _remember(self, url):
         urlparsed = urllib.parse.urlparse(url)
-        robots_url = url.replace(urlparsed.path, '/robots.txt')
+        robots_url = "%s://%s/robots.txt" % (urlparsed.scheme, urlparsed.netloc)
         write_log('ROBOTS',
                   'Reading robots.txt file at: {0}'.format(robots_url),
                   package='reppy')


### PR DESCRIPTION
A URL with trailing slash could cause it to fail e.g. https://en.wikipedia.org/
URLs having the path as a substring of the domain could also fail because of the string replace occurring too many times e.g. http://example.com/example


## Checklist

- [x] This Pull will not add the same thing as another currently-open request.
- [x] Your Pull was made against the `rivermont:dev` branch and not `rivermont:master`.
- [x] This Pull does not commit any keys, passwords, personal data, or other private information.
- [ ] I updated lines 20 and 21 in the README to reflect any changed I made.


